### PR TITLE
Fix error with multiple GPUs

### DIFF
--- a/momentumnet/exact_rep_pytorch.py
+++ b/momentumnet/exact_rep_pytorch.py
@@ -29,7 +29,7 @@ class TorchExactRep(object):
             self.aux = BitStore(0, 0, store=store)
         else:
             if device is None:
-                device = val.device.type
+                device = val.device
             if shape is not None:
                 self.intrep = torch.zeros(
                     *shape, dtype=torch.long, device=device


### PR DESCRIPTION
When using multiple GPUs in the same machine, for example GPU 0 and GPU 1, if the model is in GPU 1, the original `val.device.type` will move the tensors to GPU 0, generating errors because model and tensors are not in the same device.

This is because `device.type` returns just `cuda` and not `cuda:0` or `cuda:1`. As the `device` variable is only used for moving tensors to the appropriated device, using `val.device` do the same job and correctly move the tensors to the desired device.